### PR TITLE
remove google analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,18 +12,6 @@
 
         <script src='js/vendor/dat.gui.min.js'></script>
         <script src='js/vendor/stats.js'></script>
-
-        <script type='text/javascript'>
-            var _gaq = _gaq || [];
-            _gaq.push(['_setAccount', 'UA-48809051-1']);
-            _gaq.push(['_trackPageview']);
-
-            (function() {
-                var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-                var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-            })();
-        </script>
     </head>
     <body>
 


### PR DESCRIPTION
Remove google analytics, for cleaner deployments.

If analytics are required for the jaxry.github.io deployment, then a non-analytics version could be offered in a new "clean" branch. 

Thanks!    We've added colorful-life to the Attogram Games website builder.  See https://github.com/attogram/games 
